### PR TITLE
Updates for 2019: Build node-sass 4.13.0 using engines supported as of October 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node-sass/
 node-sass/node_modules
-build/
+dist/
 Dockerfile.*
 

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ dockerfile() {
 	cat <<- EOF > $file
 	FROM ${base_image_name}
 	ARG NODE_SASS_VERSION
-	RUN apk add --no-cache python=2.7.14-r0 git-perl bash make gcc g++
+	RUN apk add --no-cache 'python<3' git-perl bash make gcc g++
 	RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 	WORKDIR /node-sass
 	COPY ./node-sass/package.json /node-sass/package.json

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-node_sass_version=4.0.0
-node_versions=( 4 6 7 )
+node_sass_version=4.13.0
+node_versions=( 6 8 10 11 12 13 )
 image_name=node-sass-alpine-builder
 
 checkout_source() {
@@ -26,7 +26,7 @@ dockerfile() {
 	cat <<- EOF > $file
 	FROM node:${version}-alpine
 	ARG NODE_SASS_VERSION
-	RUN apk add --no-cache python=2.7.12-r0 git-perl bash make gcc g++
+	RUN apk add --no-cache python=2.7.14-r0 git-perl bash make gcc g++
 	RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 	WORKDIR /node-sass
 	COPY ./node-sass/package.json /node-sass/package.json

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ dockerfile() {
 build_docker_image() {
 	local version="$1"
 	dockerfile "$version" "Dockerfile.${version}"
-	echo "Building $image_name:${version}"
+	echo "Preparing Docker image \"$image_name:${version}\""
 	docker build --tag "$image_name:${version}" -f "Dockerfile.${version}" \
 		--build-arg NODE_SASS_VERSION=${node_sass_version} .
 	rm "Dockerfile.${version}"
@@ -56,7 +56,7 @@ build_node_sass() {
 		"/node-sass/node_modules"
 		"$PWD/build/${exact_version}:/build"
 	)
-	echo "Building node $exact_version"
+	echo "Building node-sass ${node_sass_version} for node $exact_version using \"$image_name:${version}\""
 	docker run \
 		${volumes[@]/#/-v } \
 		-it --rm "$image_name:${version}" \

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ run_inside_container() {
 	local volumes=(
 		"$PWD/node-sass:/node-sass"
 		"/node-sass/node_modules"
-		"$PWD/build/${running_node_version?need running node version}:/build"
+		"$PWD/dist/${running_node_version?need running node version}:/dist"
 	)
 	docker run \
 		${volumes[@]/#/-v } \
@@ -65,11 +65,11 @@ run_inside_container() {
 build_node_sass() {
 	inside_node_version
 	echo "Building node-sass ${node_sass_version} for node ${running_node_version} using \"${docker_image_name}\""
-	run_inside_container bash -c "node scripts/build.js -f --verbose && cp -a vendor/* /build"
+	run_inside_container bash -c "node scripts/build.js -f --verbose && cp -a vendor/* /dist"
 }
 
-rename_build_files() {
-	find build -type f -name 'binding.node' | while read FILE ; do
+rename_dist_files() {
+	find dist -type f -name 'binding.node' | while read FILE ; do
 		mv "${FILE}" $(sed -e 's#linux-x64#linux_musl-x64#' <<< "$FILE" | sed -e 's#/binding#_binding#')
 		rmdir $(dirname $FILE)
 	done
@@ -79,8 +79,8 @@ rename_build_files() {
 ## ----------------
 
 ## Output format should be like
-# * build/v4.0.0
-# * build/v4.0.0/linux_musl-x64-42_binding.node
+# * dist/v4.0.0
+# * dist/v4.0.0/linux_musl-x64-42_binding.node
 
 checkout_source "$node_sass_version"
 
@@ -90,4 +90,4 @@ for major_node_version in "${node_versions[@]}" ; do
 	build_node_sass
 done
 
-rename_build_files
+rename_dist_files

--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,14 @@ node_versions=( 6 8 10 11 12 13 )
 image_name="node-sass-alpine-builder"
 
 checkout_source() {
-	local version="$1"
-	echo "Checking out node-sass v${version}"
+	local node_sass_tag="v${1?need node sass version}"
+	echo "Checking out node-sass ${node_sass_tag}"
 	[[ -d node-sass/.git ]] || git clone https://github.com/sass/node-sass --recursive
 	(
 	cd node-sass
 	rm -rf vendor/
 	git clean -f -d
-	git checkout "v$version"
+	git checkout "${node_sass_tag}"
 	git submodule update --init --recursive
 	)
 }

--- a/build.sh
+++ b/build.sh
@@ -66,8 +66,6 @@ inside_node_version() {
 
 run_inside_container() {
 	local volumes=(
-		"$PWD/node-sass:/node-sass:Z"
-		"/node-sass/node_modules"
 		"$PWD/dist/${running_node_version?need running node version}:/dist:Z"
 	)
 	docker run \

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,9 @@ set -euo pipefail
 
 node_sass_version="4.13.0"
 image_name="node-sass-alpine-builder"
-supported_node_versions="6|8|10|11|12|13"
+default_node_versions="6 8 10 11 12 13"
 
-IFS="|" expanded_versions="${supported_node_versions}"
-set -- ${1-${expanded_versions}}
+set -- ${1-${default_node_versions}}
 for node_major_version
 do
 	case "${node_major_version}" in

--- a/build.sh
+++ b/build.sh
@@ -53,9 +53,9 @@ inside_node_version() {
 
 run_inside_container() {
 	local volumes=(
-		"$PWD/node-sass:/node-sass"
+		"$PWD/node-sass:/node-sass:Z"
 		"/node-sass/node_modules"
-		"$PWD/dist/${running_node_version?need running node version}:/dist"
+		"$PWD/dist/${running_node_version?need running node version}:/dist:Z"
 	)
 	docker run \
 		${volumes[@]/#/-v } \

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
-node_sass_version=4.13.0
-node_versions=( 6 8 10 11 12 13 )
+node_sass_version="4.13.0"
 image_name="node-sass-alpine-builder"
+supported_node_versions="6|8|10|11|12|13"
+
+IFS="|" expanded_versions="${supported_node_versions}"
+set -- ${1-${expanded_versions}}
+for node_major_version
+do
+	case "${node_major_version}" in
+	6|8|10|11|12|13)
+		;;
+	*)
+		echo >&2 "Node version \"${node_major_version}\" not supported"
+		exit 1
+		;;
+	esac
+done
 
 checkout_source() {
 	local node_sass_tag="v${1?need node sass version}"
@@ -82,9 +96,9 @@ rename_dist_files() {
 # * dist/v4.0.0
 # * dist/v4.0.0/linux_musl-x64-42_binding.node
 
-checkout_source "$node_sass_version"
-
-for major_node_version in "${node_versions[@]}" ; do
+checkout_source "${node_sass_version}"
+for major_node_version
+do
 	docker_image_name="${image_name}:${major_node_version}"
 	build_docker_image "${major_node_version}"
 	build_node_sass


### PR DESCRIPTION
Also allow to specify node major versions on the commandline